### PR TITLE
Fetch sample data IDs dynamically

### DIFF
--- a/server/boot/sample-orders.js
+++ b/server/boot/sample-orders.js
@@ -2,27 +2,31 @@ module.exports = function(app) {
   app.dataSources.db.automigrate('Order', function(err) {
     if (err) throw err;
 
-    var orders = [
-      {description: 'Order A', total: 200.45, customerId: 1},
-      {description: 'Order B', total: 100,    customerId: 1},
-      {description: 'Order C', total: 350.45, customerId: 1},
-      {description: 'Order D', total: 150.45, customerId: 2},
-      {description: 'Order E', total: 10}
-    ];
+    app.models.Customer.find(function(err, customers) {
+      if (err) throw err;
 
-    var count = orders.length;
+      var orders = [
+        {description: 'Order A', total: 200.45, customerId: customers[0].id},
+        {description: 'Order B', total: 100,    customerId: customers[0].id},
+        {description: 'Order C', total: 350.45, customerId: customers[0].id},
+        {description: 'Order D', total: 150.45, customerId: customers[1].id},
+        {description: 'Order E', total: 10}
+      ];
 
-    orders.forEach(function(order) {
-      app.models.Order.create(order, function(err, instance) {
-        if (err)
-          return console.log(err);
+      var count = orders.length;
 
-        console.log('Order created:', instance);
+      orders.forEach(function(order) {
+        app.models.Order.create(order, function(err, instance) {
+          if (err)
+            return console.log(err);
 
-        count--;
+          console.log('Order created:', instance);
 
-        if (count === 0)
-          console.log('done');
+          count--;
+
+          if (count === 0)
+            console.log('done');
+        });
       });
     });
   });

--- a/server/boot/sample-reviews.js
+++ b/server/boot/sample-reviews.js
@@ -1,26 +1,30 @@
-var reviews = [
-  {product: 'Product1', star: 3, authorId: 1},
-  {product: 'Product2', star: 2, authorId: 2},
-  {product: 'Product5', star: 5}
-];
-
 module.exports = function(app) {
   app.dataSources.db.automigrate('Review', function(err) {
     if (err) throw err;
 
-    var count = reviews.length;
+    app.models.Customer.find(function(err, customers) {
+      if (err) throw err;
 
-    reviews.forEach(function(review) {
-      app.models.Review.create(review, function(err, instance) {
-        if (err)
-          return console.log(err);
+      var reviews = [
+        {product: 'Product1', star: 3, authorId: customers[0].id},
+        {product: 'Product2', star: 2, authorId: customers[1].id},
+        {product: 'Product5', star: 5}
+      ];
 
-        console.log('Review created:', instance);
+      var count = reviews.length;
 
-        count--;
+      reviews.forEach(function(review) {
+        app.models.Review.create(review, function(err, instance) {
+          if (err)
+            return console.log(err);
 
-        if (count === 0)
-          console.log('done');
+          console.log('Review created:', instance);
+
+          count--;
+
+          if (count === 0)
+            console.log('done');
+        });
       });
     });
   });

--- a/server/server.js
+++ b/server/server.js
@@ -15,8 +15,11 @@ app.set('json spaces', 2); // format json responses for easier viewing
 // the project root
 app.set('views', path.resolve(__dirname, 'views'));
 
-app.use('/', function(req, res) {
-  res.render('index');
+app.use('/', function(req, res, next) {
+  app.models.Customer.findOne(function(err, customer) {
+    if (err) return next(err);
+    res.render('index', {customer: customer});
+  });
 });
 
 app.start = function() {

--- a/server/views/index.ejs
+++ b/server/views/index.ejs
@@ -12,10 +12,10 @@
     <ul>
       <li><a href='/api/customers'>/api/customers</a>
       <li><a href='/api/customers?filter[fields][name]=true'>/api/customers?filter[fields][name]=true</a>
-      <li><a href='/api/customers/1'>/api/customers/1</a>
+      <li><a href='/api/customers/<%= customer.id %>'>/api/customers/<%= customer.id %></a>
       <li><a href='/api/customers/youngFolks'>/api/customers/youngFolks</a>
-      <li><a href='/api/customers/1/reviews'>/api/customers/1/reviews</a>
-      <li><a href='/api/customers/1/orders'>/api/customers/1/orders</a>
+      <li><a href='/api/customers/<%= customer.id %>/reviews'>/api/customers/<%= customer.id %>/reviews</a>
+      <li><a href='/api/customers/<%= customer.id %>/orders'>/api/customers/<%= customer.id %>/orders</a>
       <li><a href='/api/customers?filter[include]=reviews'>/api/customers?filter[include]=reviews</a>
       <li><a href='/api/customers?filter[include][reviews]=author'>/api/customers?filter[include][reviews]=author</a>
       <li><a href='/api/customers?filter[include][reviews]=author&filter[where][age]=21'>/api/customers?filter[include][reviews]=author&filter[where][age]=21</a>


### PR DESCRIPTION
This fix replaces hardcoded number type IDs with dynamically fetched ID values
instead. This allows MongoDB ObjectIds to work properly with the example.
