### PR TITLE
minor typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ```
 $ git clone https://github.com/strongloop/loopback-example-relations.git
-$ cd loopback-example-model-relations
+$ cd loopback-example-relations
 $ npm install
 $ node .
 ```


### PR DESCRIPTION
`cd` bad directory name in the example
