### PR TITLE
Change property to foreignKey

### DIFF
--- a/common/models/customer.json
+++ b/common/models/customer.json
@@ -33,7 +33,7 @@
     "accounts": {
       "type": "referencesMany",
       "model": "Account",
-      "property": "accountIds",
+      "foreignKey": "accountIds",
       "options": {
         "validate": true,
         "forceId": false


### PR DESCRIPTION
A minor change, related to https://github.com/strongloop/loopback/issues/2020#issuecomment-178661260

`property` is the name used in [embedsOne](https://github.com/strongloop/loopback-datasource-juggler/blob/934786200b0180ed3d3cf45f78986b2019511e79/lib/relation-definition.js#L2225) and [embedsMany](https://github.com/strongloop/loopback-datasource-juggler/blob/934786200b0180ed3d3cf45f78986b2019511e79/lib/relation-definition.js#L1945)
But in referencesMany it's called `foreignKey`

see [`var fk = params.foreignKey || i8n.camelize(modelTo.modelName + '_ids', true);`](https://github.com/strongloop/loopback-datasource-juggler/blob/934786200b0180ed3d3cf45f78986b2019511e79/lib/relation-definition.js#L2851)
and [`keyFrom: fk`](https://github.com/strongloop/loopback-datasource-juggler/blob/934786200b0180ed3d3cf45f78986b2019511e79/lib/relation-definition.js#L2859)
in definition of referencesMany

Could you review it @superkhau ? Thanks.
